### PR TITLE
FIX properly set font properties object

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,8 +66,8 @@ Here are parameters that can either be customized in the constructor of the
   * ``scalebar.box_alpha``: transparency of box (default: ``1.0``)
   * ``scalebar.label_top``: if True, the label will be over the scale bar
     (default: ``False``)
-  * ``scalebar.font_properties``: a matplotlib.font_manager.FontProperties instance, 
-    optional sets the font properties for the label text
+  * ``scalebar.font_properties``: font properties of the label text, specified
+    either as dict or `fontconfig <http://www.fontconfig.org/>`_ pattern (XML).
 
 License
 -------

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -151,7 +151,7 @@ class ScaleBar(Artist):
         self.box_alpha = box_alpha
         self.scale_loc = scale_loc
         self.label_loc = label_loc
-        self.font_properties = FontProperties(font_properties)
+        self.font_properties = FontProperties(_init=font_properties)
 
     def _calculate_length(self, length_px):
         dx_m = self.dx_m

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -132,8 +132,9 @@ class ScaleBar(Artist):
             (default: rcParams['scalebar.scale_loc'] or ``bottom``)
         :arg label_loc: either ``bottom``, ``top``, ``left``, ``right``
             (default: rcParams['scalebar.label_loc'] or ``top``)
-        :arg font_properties: a matplotlib.font_manager.FontProperties instance, 
-            optional sets the font properties for the label text
+        :arg font_properties: font properties of the label text, specified
+            either as dict or `fontconfig <http://www.fontconfig.org/>`_
+            pattern (XML).
         """
         Artist.__init__(self)
 
@@ -151,7 +152,16 @@ class ScaleBar(Artist):
         self.box_alpha = box_alpha
         self.scale_loc = scale_loc
         self.label_loc = label_loc
-        self.font_properties = FontProperties(_init=font_properties)
+        if font_properties is None:
+            font_properties = FontProperties()
+        elif isinstance(font_properties, dict):
+            font_properties = FontProperties(**font_properties)
+        elif is_string_like(font_properties):
+            font_properties = FontProperties(font_properties)
+        else:
+            raise TypeError("Unsupported type for `font_properties`. Pass "
+                            "either a dict or a font config pattern as string.")
+        self.font_properties = font_properties
 
     def _calculate_length(self, length_px):
         dx_m = self.dx_m

--- a/matplotlib_scalebar/test_scalebar.py
+++ b/matplotlib_scalebar/test_scalebar.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from nose.tools import \
     (assert_equal, assert_almost_equal, assert_is_none, assert_true,
-     assert_false, assert_raises)
+     assert_false, assert_raises, raises)
 
 # Local modules.
 from matplotlib_scalebar.scalebar import ScaleBar
@@ -166,11 +166,16 @@ def test_scalebar_frameon():
     
 @cleanup
 def test_scalebar_font_properties():
-    font_settings = fm.FontProperties(family='serif', size=9)
+    font_settings = dict(family='serif', size=9)
     scalebar = ScaleBar(0.5, font_properties=font_settings)
     
     assert_equal(scalebar.font_properties.get_family(), ['serif'])
     assert_equal(scalebar.font_properties.get_size(), 9)
+    
+@cleanup
+@raises(TypeError)
+def test_scalebar_font_properties_invalid_type():
+    ScaleBar(0.5, font_properties=2.0)
     
 
 if __name__ == '__main__':

--- a/matplotlib_scalebar/test_scalebar.py
+++ b/matplotlib_scalebar/test_scalebar.py
@@ -6,6 +6,7 @@
 # Third party modules.
 import matplotlib
 matplotlib.use('agg')
+import matplotlib.font_manager as fm
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import cleanup
 
@@ -162,6 +163,15 @@ def test_scalebar_frameon():
     scalebar.frameon = False
     assert_false(scalebar.get_frameon())
     assert_false(scalebar.frameon)
+    
+@cleanup
+def test_scalebar_font_properties():
+    font_settings = fm.FontProperties(family='serif', size=9)
+    scalebar = ScaleBar(0.5, font_properties=font_settings)
+    
+    assert_equal(scalebar.font_properties.get_family(), ['serif'])
+    assert_equal(scalebar.font_properties.get_size(), 9)
+    
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
When setting the argument `font_properties` a `TypeError` exception was raised due to improper initialization of the `FontProperties` object.
This pull request fixes the issue, test included.

Tested on Windows 7, x64 with
matplotlib=1.5.1
numpy=1.11.1

Another idea for font management would be passing a dict to `font_properties` and creating the FontProperties object using keyword arguments in `__init__(...)`:

``` python
scalebar = ScaleBar(0.1, font_properties=dict(family='serif', size=9))

# in Scalebar.__init__(...)
self.font_properties = FontProperties(**font_properties)
```
