### PR TITLE
WIP: Added Option to create custom Label Formatter

### DIFF
--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,6 +1,0 @@
-This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
-
-This directory caches those eggs to prevent repeated downloads.
-
-However, it is safe to delete this directory.
-

--- a/.eggs/README.txt
+++ b/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ local.properties
 # TeXlipse plugin
 .texlipse
 
+#####=== PyCharm ===#####
+.idea
+
 #####=== Python ===#####
 
 # Byte-compiled / optimized / DLL files

--- a/README.rst
+++ b/README.rst
@@ -3,13 +3,13 @@ matplotlib-scalebar
 
 .. image:: https://travis-ci.org/ppinard/matplotlib-scalebar.svg
    :target: https://travis-ci.org/ppinard/matplotlib-scalebar
-   
+
 .. image:: https://badge.fury.io/py/matplotlib-scalebar.svg
    :target: http://badge.fury.io/py/matplotlib-scalebar
 
 Provides a new artist for matplotlib to display a scale bar, aka micron bar.
-It is particularly useful when displaying calibrated images plotted using 
-plt.imshow(...). 
+It is particularly useful when displaying calibrated images plotted using
+plt.imshow(...).
 
 .. image:: https://raw.githubusercontent.com/ppinard/matplotlib-scalebar/master/doc/example1.png
 
@@ -22,7 +22,7 @@ Installation
 Easiest way to install using ``pip``::
 
     $ pip install matplotlib-scalebar
-    
+
 For development installation from the git repository::
 
     $ git clone git@github.com:ppinard/matplotlib-scalebar.git
@@ -42,7 +42,7 @@ Here is an example how to add a scale bar::
    >>> scalebar = ScaleBar(0.2) # 1 pixel = 0.2 meter
    >>> plt.gca().add_artist(scalebar)
    >>> plt.show()
-   
+
 The scale bar also works with reciprocal units,::
 
    >>> from matplotlib_scalebar.scalebar import SI_LENGTH_RECIPROCAL
@@ -52,9 +52,9 @@ imperial units::
 
    >>> from matplotlib_scalebar.scalebar import IMPERIAL_LENGTH
    >>> scalebar = ScaleBar(0.2, 'ft', IMPERIAL_LENGTH) # 1 pixel = 0.2 feet
-   
+
 .. image:: https://raw.githubusercontent.com/ppinard/matplotlib-scalebar/master/doc/example2.png
-   
+
 and system defined by the **Dimension** class.
 
 ScaleBar arguments
@@ -62,23 +62,23 @@ ScaleBar arguments
 
 Here are parameters of the **ScaleBar** class constructor.
 
-  * ``dx``: Size of one pixel in *units* specified by the next argument (required). 
+  * ``dx``: Size of one pixel in *units* specified by the next argument (required).
     Set ``dx`` to 1.0 if the axes image has already been calibrated by
     setting its ``extent``.
   * ``units``: units of *dx* (default: ``m``)
-  * ``dimension``: dimension of *dx* and *units*. 
-    It can either be equal 
-    
+  * ``dimension``: dimension of *dx* and *units*.
+    It can either be equal
+
         * ``SI_LENGTH``: scale bar showing km, m, cm, etc.
         * ``IMPERIAL_LENGTH``: scale bar showing in, ft, yd, mi, etc.
         * ``SI_LENGTH_RECIPROCAL``: scale bar showing 1/m, 1/cm, etc.
         * a ``matplotlib_scalebar.dimension._Dimension`` object
-  
-  * ``label``: optional label associated with the scale bar 
+
+  * ``label``: optional label associated with the scale bar
     (default: ``None``, no label is shown)
-  * ``length_fraction``: length of the scale bar as a fraction of the 
+  * ``length_fraction``: length of the scale bar as a fraction of the
     axes's width (default: ``rcParams['scalebar.lenght_fraction']`` or ``0.2``)
-  * ``height_fraction``: height of the scale bar as a fraction of the 
+  * ``height_fraction``: height of the scale bar as a fraction of the
     axes's height (default: ``rcParams['scalebar.height_fraction']`` or ``0.01``)
   * ``location``: a location code (same as legend)
     (default: ``rcParams['scalebar.location']`` or ``upper right``)
@@ -88,7 +88,7 @@ Here are parameters of the **ScaleBar** class constructor.
     (default: ``rcParams['scalebar.border_pad']`` or ``0.1``)
   * ``sep``: separation between scale bar and label in points
     (default: ``rcParams['scalebar.sep']`` or ``5``)
-  * ``frameon``: if ``True``, will draw a box around the scale bar and label 
+  * ``frameon``: if ``True``, will draw a box around the scale bar and label
     (default: ``rcParams['scalebar.frameon']`` or ``True``)
   * ``color``: color for the scale bar and label
     (default: ``rcParams['scalebar.color']`` or ``k``)
@@ -100,25 +100,28 @@ Here are parameters of the **ScaleBar** class constructor.
     (default: ``rcParams['scalebar.scale_loc']`` or ``bottom``)
   * ``label_loc``: either ``bottom``, ``top``, ``left``, ``right``
     (default: ``rcParams['scalebar.label_loc']`` or ``top``)
-  * ``font_properties``: font properties of the label text, specified either as 
+  * ``font_properties``: font properties of the label text, specified either as
     dict or `fontconfig <http://www.fontconfig.org/>`_ pattern (XML).
+  * ``label_formatter``: custom function called to format the scalebar text.
+    Needs to take 2 arguments - the scale value and the unit.
+    (default: ``None`` which results in ``<value> <unit>``)
 
 matplotlibrc parameters
 -----------------------
 
 Here are parameters that can be customized in the matplotlibrc file.
 
-  * ``scalebar.length_fraction``: length of the scale bar as a fraction of the 
+  * ``scalebar.length_fraction``: length of the scale bar as a fraction of the
     axes's width (default: ``0.2``)
-  * ``scalebar.height_fraction``: height of the scale bar as a fraction of the 
+  * ``scalebar.height_fraction``: height of the scale bar as a fraction of the
     axes's height (default: ``0.01``)
   * ``scalebar.location``: a location code (same as legend)
     (default: ``upper right``)
   * ``scalebar.pad``: fraction of the font size (default: ``0.2``)
   * ``scalebar.border_pad``: fraction of the font size (default: ``0.1``)
-  * ``scalebar.sep``: separation between scale bar and label in points 
+  * ``scalebar.sep``: separation between scale bar and label in points
     (default: ``5``)
-  * ``scalebar.frameon``: if True, will draw a box around the scale bar 
+  * ``scalebar.frameon``: if True, will draw a box around the scale bar
     and label (default: ``True``)
   * ``scalebar.color``: color for the scale bar and label (default: ``k``)
   * ``scalebar.box_color``: color of the box (if *frameon*) (default: ``w``)

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -113,7 +113,7 @@ class ScaleBar(Artist):
                  length_fraction=None, height_fraction=None,
                  location=None, pad=None, border_pad=None, sep=None,
                  frameon=None, color=None, box_color=None, box_alpha=None,
-                 scale_loc=None, label_loc=None, font_properties=None, label_formater=None):
+                 scale_loc=None, label_loc=None, font_properties=None, label_formatter=None):
         """
         Creates a new scale bar.
         
@@ -192,10 +192,10 @@ class ScaleBar(Artist):
         :type font_properties: :class:`matplotlib.font_manager.FontProperties`,
             :class:`str` or :class:`dict`
 
-        :arg label_formater: function used to format the label. Needs to take
+        :arg label_formatter: function used to format the label. Needs to take
             the value (float) and the unit (str) as input and return the label
             string.
-        :type label_formater: :class:`func`
+        :type label_formatter: :class:`func`
         """
         Artist.__init__(self)
 
@@ -216,7 +216,7 @@ class ScaleBar(Artist):
         self.scale_loc = scale_loc
         self.label_loc = label_loc
         default_formatter = lambda value, unit: '{} {}'.format(value, unit)
-        self.label_formatter = label_formater or default_formatter
+        self.label_formatter = label_formatter or default_formatter
         if font_properties is None:
             font_properties = FontProperties()
         elif isinstance(font_properties, dict):

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -502,3 +502,11 @@ class ScaleBar(Artist):
         self._font_properties = props
 
     font_properties = property(get_font_properties, set_font_properties)
+
+    def get_label_formatter(self):
+        return self._label_formatter
+
+    def set_label_formatter(self, label_formatter):
+        self._label_formatter = float(label_formatter)
+
+    label_formatter = property(get_label_formatter, set_label_formatter)

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -113,7 +113,7 @@ class ScaleBar(Artist):
                  length_fraction=None, height_fraction=None,
                  location=None, pad=None, border_pad=None, sep=None,
                  frameon=None, color=None, box_color=None, box_alpha=None,
-                 scale_loc=None, label_loc=None, font_properties=None):
+                 scale_loc=None, label_loc=None, font_properties=None, label_formater=None):
         """
         Creates a new scale bar.
         
@@ -191,6 +191,11 @@ class ScaleBar(Artist):
             pattern (XML).
         :type font_properties: :class:`matplotlib.font_manager.FontProperties`,
             :class:`str` or :class:`dict`
+
+        :arg label_formater: function used to format the label. Needs to take
+            the value (float) and the unit (str) as input and return the label
+            string.
+        :type label_formater: :class:`func`
         """
         Artist.__init__(self)
 
@@ -210,6 +215,8 @@ class ScaleBar(Artist):
         self.box_alpha = box_alpha
         self.scale_loc = scale_loc
         self.label_loc = label_loc
+        default_formatter = lambda value, unit: '{} {}'.format(value, unit)
+        self.label_formatter = label_formater or default_formatter
         if font_properties is None:
             font_properties = FontProperties()
         elif isinstance(font_properties, dict):
@@ -233,7 +240,7 @@ class ScaleBar(Artist):
         newvalue = self._PREFERRED_VALUES[index - 1]
 
         length_px = newvalue * factor / dx
-        label = '%i %s' % (newvalue, self.dimension.to_latex(newunits))
+        label = self.label_formatter(newvalue, self.dimension.to_latex(newunits))
 
         return length_px, label
 

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -507,6 +507,6 @@ class ScaleBar(Artist):
         return self._label_formatter
 
     def set_label_formatter(self, label_formatter):
-        self._label_formatter = float(label_formatter)
+        self._label_formatter = label_formatter
 
     label_formatter = property(get_label_formatter, set_label_formatter)

--- a/matplotlib_scalebar/test_scalebar.py
+++ b/matplotlib_scalebar/test_scalebar.py
@@ -179,6 +179,20 @@ def test_scalebar_font_properties_invalid_type():
 def test_matplotlibrc():
     matplotlib.rcParams['scalebar.box_color'] = 'r'
 
+@cleanup
+def test_custom_label_format():
+    _fig, _ax, scalebar = create_figure()
+    scalebar.dx = 1
+    scalebar.units = 'm'
+    assert_equal(scalebar._calculate_length(10)[1], '5 m')
+    scalebar.label_formatter = lambda value, unit: 'test'
+    assert_equal(scalebar._calculate_length(1)[1], 'test')
+    scalebar.label_formatter = lambda value, unit: '{} {}'.format(unit, value)
+    assert_equal(scalebar._calculate_length(10)[1], 'm 5')
+
+
+
+
 if __name__ == '__main__':
     import nose
     import sys


### PR DESCRIPTION
Hey,

I added the option to completely customize the unit label by providing a label_formatter (a function that takes the value and the unit as input and outputs the label string). This should help in all cases, were you need something completely custom or as a quick fix, if non of the predefined units work.

I am not happy with the tests yet, but they should cover the main functionality. If you are interested in merging that feature, I will add an example and a Note in the README.

Regards,
Arne