### PR TITLE
Fix deprecated usage of is_string_like 

### DIFF
--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -37,7 +37,6 @@ import bisect
 # Third party modules.
 import matplotlib
 from matplotlib.artist import Artist
-from matplotlib.cbook import is_string_like
 from matplotlib.font_manager import FontProperties
 from matplotlib.rcsetup import \
     (defaultParams, validate_float, validate_legend_loc, validate_bool,

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -241,7 +241,7 @@ class ScaleBar(Artist):
             font_properties = FontProperties()
         elif isinstance(font_properties, dict):
             font_properties = FontProperties(**font_properties)
-        elif is_string_like(font_properties):
+        elif isinstance(font_properties, six.string_types):
             font_properties = FontProperties(font_properties)
         else:
             raise TypeError("Unsupported type for `font_properties`. Pass "
@@ -287,7 +287,7 @@ class ScaleBar(Artist):
         length_fraction = _get_value('length_fraction', 0.2)
         height_fraction = _get_value('height_fraction', 0.01)
         location = _get_value('location', 'upper right')
-        if is_string_like(location):
+        if isinstance(location, six.string_types):
             location = self._LOCATIONS[location]
         pad = _get_value('pad', 0.2)
         border_pad = _get_value('border_pad', 0.1)
@@ -446,7 +446,7 @@ class ScaleBar(Artist):
         return self._location
 
     def set_location(self, loc):
-        if is_string_like(loc):
+        if isinstance(loc, six.string_types):
             if loc not in self._LOCATIONS:
                 raise ValueError('Unknown location code: %s' % loc)
             loc = self._LOCATIONS[loc]


### PR DESCRIPTION
is_string_like is deprecated for matplotlib>=2.1.0 (and throws some annoying warnings). 
This should fix this. 

similar to
- https://github.com/matplotlib/matplotlib/pull/8535
