### PR TITLE
Add blit support and fix documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,7 @@ Here are parameters of the **ScaleBar** class constructor.
   * ``imperial-length``: scale bar showing in, ft, yd, mi, etc.
   * ``si-length-reciprocal``: scale bar showing 1/m, 1/cm, etc.
   * ``pixel-length``: scale bar showing px, kpx, Mpx, etc.
+  * a ``matplotlib_scalebar.dimension._Dimension`` object
 
 * ``label``: optional label associated with the scale bar
   (default: ``None``, no label is shown)
@@ -134,6 +135,7 @@ Here are parameters of the **ScaleBar** class constructor.
   automatically determined based on *length_fraction*.
 * ``fixed_units``: units of the *fixed_value*. If ``None`` and
   *fixed_value* is not ``None``, the units of *dx* are used.
+* ``animated``: animation state (default: ``False``)
 
 matplotlibrc parameters
 -----------------------

--- a/README.rst
+++ b/README.rst
@@ -94,11 +94,10 @@ Here are parameters of the **ScaleBar** class constructor.
 * ``dimension``: dimension of *dx* and *units*.
   It can either be equal
 
-  * ``SI_LENGTH``: scale bar showing km, m, cm, etc.
-  * ``IMPERIAL_LENGTH``: scale bar showing in, ft, yd, mi, etc.
-  * ``SI_LENGTH_RECIPROCAL``: scale bar showing 1/m, 1/cm, etc.
-  * ``PIXEL_LENGTH``: scale bar showing px, kpx, Mpx, etc.
-  * a ``matplotlib_scalebar.dimension._Dimension`` object
+  * ``si-length``: scale bar showing km, m, cm, etc.
+  * ``imperial-length``: scale bar showing in, ft, yd, mi, etc.
+  * ``si-length-reciprocal``: scale bar showing 1/m, 1/cm, etc.
+  * ``pixel-length``: scale bar showing px, kpx, Mpx, etc.
 
 * ``label``: optional label associated with the scale bar
   (default: ``None``, no label is shown)

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -251,7 +251,7 @@ class ScaleBar(Artist):
         self.font_properties = font_properties
         self.fixed_value = fixed_value
         self.fixed_units = fixed_units
-        self.animated = animated
+        self.set_animated(animated)
 
     def _calculate_best_length(self, length_px):
         dx = self.dx
@@ -380,7 +380,6 @@ class ScaleBar(Artist):
         box.patch.set_color(box_color)
         box.patch.set_alpha(box_alpha)
         box.draw(renderer)
-        self.set_animated(self.animated)
 
     def get_dx(self):
         return self._dx

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -116,7 +116,7 @@ class ScaleBar(Artist):
                  frameon=None, color=None, box_color=None, box_alpha=None,
                  scale_loc=None, label_loc=None, font_properties=None,
                  label_formatter=None, fixed_value=None, fixed_units=None,
-                 use_blit=False):
+                 animated=False):
         """
         Creates a new scale bar.
         
@@ -251,7 +251,7 @@ class ScaleBar(Artist):
         self.font_properties = font_properties
         self.fixed_value = fixed_value
         self.fixed_units = fixed_units
-        self.use_blit = use_blit
+        self.animated = animated
 
     def _calculate_best_length(self, length_px):
         dx = self.dx
@@ -380,7 +380,7 @@ class ScaleBar(Artist):
         box.patch.set_color(box_color)
         box.patch.set_alpha(box_alpha)
         box.draw(renderer)
-        self.set_animated(self.use_blit)
+        self.set_animated(self.animated)
 
     def get_dx(self):
         return self._dx

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -29,7 +29,7 @@ parameters.
 """
 
 __all__ = ['ScaleBar',
-           'SI_LENGTH', 'SI_LENGTH_RECIPROCAL', 'IMPERIAL_LENGTH']
+           'SI_LENGTH', 'SI_LENGTH_RECIPROCAL', 'IMPERIAL_LENGTH', 'PIXEL_LENGTH']
 
 # Standard library modules.
 import bisect
@@ -144,6 +144,7 @@ class ScaleBar(Artist):
                 * ``:const:`imperial-length```: scale bar showing in, ft, yd, mi, etc.
                 * ``:const:`si-length-reciprocal```: scale bar showing 1/m, 1/cm, etc.
                 * ``:const:`pixel-length```: scale bar showing px, kpx, Mpx, etc.
+                * a :class:`matplotlib_scalebar.dimension._Dimension` object
         :type dimension: :class:`str` or 
             :class:`matplotlib_scalebar.dimension._Dimension`
                 
@@ -218,6 +219,9 @@ class ScaleBar(Artist):
         :arg fixed_units: units of the *fixed_value*. If ``None`` and
             *fixed_value* is not ``None``, the units of *dx* are used.
         :type fixed_units: :class:`str`
+        
+        :arg animated: animation state (default: ``False``)
+        :type animated: :class`bool`
         """
         Artist.__init__(self)
 

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -110,7 +110,7 @@ class ScaleBar(Artist):
                   'center':       10,
               }
 
-    def __init__(self, dx, units='m', dimension=SI_LENGTH, label=None,
+    def __init__(self, dx, units='m', dimension='si-length', label=None,
                  length_fraction=None, height_fraction=None,
                  location=None, pad=None, border_pad=None, sep=None,
                  frameon=None, color=None, box_color=None, box_alpha=None,
@@ -140,11 +140,10 @@ class ScaleBar(Artist):
         
         :arg dimension: dimension of *dx* and *units*. 
             It can either be equal 
-                * ``:const:`SI_LENGTH```: scale bar showing km, m, cm, etc.
-                * ``:const:`IMPERIAL_LENGTH```: scale bar showing in, ft, yd, mi, etc.
-                * ``:const:`SI_LENGTH_RECIPROCAL```: scale bar showing 1/m, 1/cm, etc.
-                * ``:const:`PIXEL_LENGTH```: scale bar showing px, kpx, Mpx, etc.
-                * a :class:`matplotlib_scalebar.dimension._Dimension` object
+                * ``:const:`si-length```: scale bar showing km, m, cm, etc.
+                * ``:const:`imperial-length```: scale bar showing in, ft, yd, mi, etc.
+                * ``:const:`si-length-reciprocal```: scale bar showing 1/m, 1/cm, etc.
+                * ``:const:`pixel-length```: scale bar showing px, kpx, Mpx, etc.
         :type dimension: :class:`str` or 
             :class:`matplotlib_scalebar.dimension._Dimension`
                 

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -115,7 +115,8 @@ class ScaleBar(Artist):
                  location=None, pad=None, border_pad=None, sep=None,
                  frameon=None, color=None, box_color=None, box_alpha=None,
                  scale_loc=None, label_loc=None, font_properties=None,
-                 label_formatter=None, fixed_value=None, fixed_units=None):
+                 label_formatter=None, fixed_value=None, fixed_units=None,
+                 use_blit=False):
         """
         Creates a new scale bar.
         
@@ -251,6 +252,7 @@ class ScaleBar(Artist):
         self.font_properties = font_properties
         self.fixed_value = fixed_value
         self.fixed_units = fixed_units
+        self.use_blit = use_blit
 
     def _calculate_best_length(self, length_px):
         dx = self.dx
@@ -379,6 +381,7 @@ class ScaleBar(Artist):
         box.patch.set_color(box_color)
         box.patch.set_alpha(box_alpha)
         box.draw(renderer)
+        self.set_animated(self.use_blit)
 
     def get_dx(self):
         return self._dx


### PR DESCRIPTION
I am looking at using `matplotlib-scalebar` in `hyperspy` as a replacement of the [current implementation of the scalebar ](https://github.com/hyperspy/hyperspy/blob/RELEASE_next_minor/hyperspy/drawing/_widgets/scalebar.py) and a few tweaks are needed to make it work.

Using this scalebar is much simpler and nicer than the current implementation of the scalebar in hyperspy. It also fixed a few bugs.