### PR TITLE
Fix issue with getting the wrong preferred values for the scale bar.

### DIFF
--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -261,7 +261,11 @@ class ScaleBar(Artist):
         factor = value / newvalue
 
         index = bisect.bisect_left(self._PREFERRED_VALUES, newvalue)
-        newvalue = self._PREFERRED_VALUES[index - 1]
+        if index > 0:
+            # When we get the lowest index of the list, removing -1 will
+            # return the last index.
+            index -= 1
+        newvalue = self._PREFERRED_VALUES[index]
 
         length_px = newvalue * factor / dx
 


### PR DESCRIPTION
Fixes the following issue:
```python
import matplotlib.pyplot as plt
import numpy as np
from matplotlib_scalebar.scalebar import ScaleBar
plt.figure()
image = np.arange(25).reshape((5, 5))
plt.imshow(image)
scalebar = ScaleBar(1, units='px', dimension='pixel-length')
plt.gca().add_artist(scalebar)
```
![image](https://user-images.githubusercontent.com/11851990/60772504-642fe880-a0ef-11e9-8c4f-30b8eea79265.png)


While we would expect:

![image](https://user-images.githubusercontent.com/11851990/60772512-7f025d00-a0ef-11e9-8a47-6bbbc1b5493a.png)

It seems that the wrong preferred value is picked up when looking up the `_PREFERRED_VALUES` list.
