### PR TITLE
Fix scalebar location validation

### DIFF
--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -89,6 +89,7 @@ _validate_rotation = ValidateInStrings("rotation", _VALID_ROTATIONS, ignorecase=
 def _validate_legend_loc(loc):
     rc = matplotlib.RcParams()
     rc["legend.loc"] = loc
+    return loc
 
 defaultParams.update(
     {

--- a/matplotlib_scalebar/test_scalebar.py
+++ b/matplotlib_scalebar/test_scalebar.py
@@ -38,6 +38,33 @@ def scalebar():
     plt.draw()
 
 
+def test_mpl_rcParams_update():
+    """
+    Test if scalebar params are updated accurately in matplotlib rcParams
+    """
+
+    params = {
+        "scalebar.length_fraction": 0.2,
+        "scalebar.height_fraction": 0.01,  # deprecated
+        "scalebar.width_fraction": 0.01,
+        "scalebar.location": "upper right",
+        "scalebar.pad": 0.2,
+        "scalebar.border_pad": 0.1,
+        "scalebar.sep": 5,
+        "scalebar.frameon": True,
+        "scalebar.color": "k",
+        "scalebar.box_color": "w",
+        "scalebar.box_alpha": 1.0,
+        "scalebar.scale_loc": "bottom",
+        "scalebar.label_loc": "top",
+        "scalebar.rotation": "horizontal",
+    }
+    matplotlib.rcParams.update(params)
+
+    for key, value in params.items():
+        assert matplotlib.rcParams[key] == value
+    
+
 def test_scalebar_dx_m(scalebar):
     assert scalebar.get_dx() == pytest.approx(0.5, abs=1e-2)
     assert scalebar.dx == pytest.approx(0.5, abs=1e-2)


### PR DESCRIPTION
The `_validate_legend_loc` function in the previous PR #33 was missing a return statement so the function returned `None`.

So, if we update the scalebar location using - `matplotilb.rcParams.update({"scalebar.location" : "upper right"})`, it will not be updated and will be set to `None` instead.

This PR fixes that bug by adding a return statement and also adds a new test to check the rcParams updates for all `matplotlib_scalebar` parameters.
