### PR TITLE
Hide scale and label

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,16 +234,18 @@ Default: `None`, value from matplotlibrc or `1.0` (opaque).
 ### scale_loc
 
 Location of the scale with respect to the scale bar.
-Either `bottom`, `top`, `left`, `right`.
+Either `bottom`, `top`, `left`, `right`, `none`.
 Default: `None`, value from matplotlibrc or `bottom`.
+If `"none"`, no scale is shown.
 
 ![scale_loc](doc/argument_scale_loc.png)
 
 ### label_loc
 
 Location of the label with respect to the scale bar.
-Either `bottom`, `top`, `left`, `right`.
+Either `bottom`, `top`, `left`, `right`, `none`.
 Default: `None`, value from matplotlibrc or `top`.
+If `"none"`, no label is shown.
 
 ### font_properties
 

--- a/doc/splashscreen.py
+++ b/doc/splashscreen.py
@@ -4,9 +4,7 @@ import requests
 from PIL import Image
 from io import BytesIO
 
-r = requests.get(
-    "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Misc_pollen.jpg/315px-Misc_pollen.jpg"
-)
+r = requests.get("https://upload.wikimedia.org/wikipedia/commons/a/a4/Misc_pollen.jpg")
 im = Image.open(BytesIO(r.content))
 
 fig = plt.figure(figsize=(4, 4 / 1.3125))
@@ -16,7 +14,7 @@ ax.imshow(im, "gray")
 
 # According to Wikipedia, "the bean shaped grain in the bottom left corner is about 50 μm long."
 scalebar = ScaleBar(
-    50 / 37, "um", location="lower right", width_fraction=0.02, border_pad=1, pad=0.5
+    50 / 144, "um", location="lower right", width_fraction=0.02, border_pad=1, pad=0.5
 )
 ax.add_artist(scalebar)
 

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -73,12 +73,12 @@ from matplotlib_scalebar.dimension import (
 # Globals and constants variables.
 
 # Setup of extra parameters in the matplotlic rc
-_VALID_SCALE_LOCATIONS = ["bottom", "top", "right", "left"]
+_VALID_SCALE_LOCATIONS = ["bottom", "top", "right", "left", "none"]
 _validate_scale_loc = ValidateInStrings(
     "scale_loc", _VALID_SCALE_LOCATIONS, ignorecase=True
 )
 
-_VALID_LABEL_LOCATIONS = ["bottom", "top", "right", "left"]
+_VALID_LABEL_LOCATIONS = ["bottom", "top", "right", "left", "none"]
 _validate_label_loc = ValidateInStrings(
     "label_loc", _VALID_LABEL_LOCATIONS, ignorecase=True
 )
@@ -265,12 +265,14 @@ class ScaleBar(Artist):
             (default: rcParams['scalebar.box_alpha'] or ``1.0``)
         :type box_alpha: :class:`float`
 
-        :arg scale_loc : either ``bottom``, ``top``, ``left``, ``right``
-            (default: rcParams['scalebar.scale_loc'] or ``bottom``)
+        :arg scale_loc : either ``bottom``, ``top``, ``left``, ``right``, ``none``
+            (default: rcParams['scalebar.scale_loc'] or ``bottom``).
+            If ``none`` the scale is not shown.
         :type scale_loc: :class:`str`
 
-        :arg label_loc: either ``bottom``, ``top``, ``left``, ``right``
-            (default: rcParams['scalebar.label_loc'] or ``top``)
+        :arg label_loc: either ``bottom``, ``top``, ``left``, ``right``, ``none``
+            (default: rcParams['scalebar.label_loc'] or ``top``).
+            If ``none`` the label is not shown.
         :type label_loc: :class:`str`
 
         :arg font_properties: font properties of the label text, specified
@@ -464,22 +466,27 @@ class ScaleBar(Artist):
         scale_bar_box = AuxTransformBox(ax.transData)
         scale_bar_box.add_artist(scale_rect)
 
-        scale_text_box = TextArea(scale_text, textprops=textprops)
+        # Create scale text
+        if scale_loc != "none":
+            scale_text_box = TextArea(scale_text, textprops=textprops)
 
-        if scale_loc in ["bottom", "right"]:
-            children = [scale_bar_box, scale_text_box]
+            if scale_loc in ["bottom", "right"]:
+                children = [scale_bar_box, scale_text_box]
+            else:
+                children = [scale_text_box, scale_bar_box]
+
+            if scale_loc in ["bottom", "top"]:
+                Packer = VPacker
+            else:
+                Packer = HPacker
+
+            scale_box = Packer(children=children, align="center", pad=0, sep=sep)
+
         else:
-            children = [scale_text_box, scale_bar_box]
-
-        if scale_loc in ["bottom", "top"]:
-            Packer = VPacker
-        else:
-            Packer = HPacker
-
-        scale_box = Packer(children=children, align="center", pad=0, sep=sep)
+            scale_box = scale_bar_box
 
         # Create label
-        if label:
+        if label and label_loc != "none":
             label_box = TextArea(label, textprops=textprops)
         else:
             label_box = None

--- a/matplotlib_scalebar/test_scalebar.py
+++ b/matplotlib_scalebar/test_scalebar.py
@@ -264,6 +264,11 @@ def test_scalebar_fixed_units(scalebar):
     assert scalebar.fixed_units == "um"
 
 
+def test_scalebar_noscale_nolabel(scalebar):
+    scalebar.scale_loc = "none"
+    scalebar.label_loc = "none"
+
+
 def test_scale_formatter(scalebar):
     scalebar.dx = 1
     scalebar.units = "m"


### PR DESCRIPTION
From #41. `scale_loc` and `label_loc` can now be set to `"none"` to hide the scale and label, respectively.