### PR TITLE
Remove useless shebangs

### DIFF
--- a/matplotlib_scalebar/test_dimension.py
+++ b/matplotlib_scalebar/test_dimension.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ """
 
 # Standard library modules.

--- a/matplotlib_scalebar/test_scalebar.py
+++ b/matplotlib_scalebar/test_scalebar.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """ """
 
 # Standard library modules.


### PR DESCRIPTION
Since these test modules don’t have script-like content (no interesting side effects, “`if __name__ == "__main__"`”, or similar), and since their file permissions do not include the executable bit, shebang lines (`#!`) aren’t useful.

This PR is trivial, but this detail is something we currently need to change downstream in Fedora Linux packaging.