### PR TITLE
Add common astronomical lengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Dimension of *dx* and *units*. It can either be equal:
 
 * `si-length` (default): scale bar showing km, m, cm, etc.
 * `imperial-length`: scale bar showing in, ft, yd, mi, etc.
+* `astro-length`: scale bar showing pc, kpc, Mpc, ly, AU, etc.
 * `si-length-reciprocal`: scale bar showing 1/m, 1/cm, etc.
 * `pixel-length`: scale bar showing px, kpx, Mpx, etc.
 * `angle`: scale bar showing °, ʹ (minute of arc) or ʹʹ (second of arc)

--- a/matplotlib_scalebar/dimension.py
+++ b/matplotlib_scalebar/dimension.py
@@ -138,12 +138,12 @@ class ImperialLengthDimension(_Dimension):
 
 class AstronomicalLengthDimension(_Dimension):
     def __init__(self):
-        super.__init__("pc")
+        super().__init__("pc")
         for prefix, factor in _PREFIXES_FACTORS.items():
             latexrepr = None
             if prefix == "\u00b5" or prefix == "u":
-                latexrepr = _LATEX_MU + "kpc"
-            self.add_units(prefix + "m", factor, latexrepr)
+                latexrepr = _LATEX_MU + "pc"
+            self.add_units(prefix + "pc", factor, latexrepr)
         self.add_units("ly", 0.30659485)
         self.add_units("AU", 4.84813681e-06)
 

--- a/matplotlib_scalebar/dimension.py
+++ b/matplotlib_scalebar/dimension.py
@@ -136,6 +136,18 @@ class ImperialLengthDimension(_Dimension):
         self.add_units("lea", 15840)
 
 
+class AstronomicalLengthDimension(_Dimension):
+    def __init__(self):
+        super.__init__("pc")
+        for prefix, factor in _PREFIXES_FACTORS.items():
+            latexrepr = None
+            if prefix == "\u00b5" or prefix == "u":
+                latexrepr = _LATEX_MU + "kpc"
+            self.add_units(prefix + "m", factor, latexrepr)
+        self.add_units("ly", 0.30659485)
+        self.add_units("AU", 4.84813681e-06)
+
+
 class PixelLengthDimension(_Dimension):
     def __init__(self):
         super().__init__("px")

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -33,6 +33,7 @@ __all__ = [
     "SI_LENGTH",
     "SI_LENGTH_RECIPROCAL",
     "IMPERIAL_LENGTH",
+    "ASTRO_LENGTH",
     "PIXEL_LENGTH",
 ]
 
@@ -66,6 +67,7 @@ from matplotlib_scalebar.dimension import (
     SILengthDimension,
     SILengthReciprocalDimension,
     ImperialLengthDimension,
+    AstronomicalLengthDimension,
     PixelLengthDimension,
     AngleDimension,
 )
@@ -126,6 +128,7 @@ matplotlib.rcParams.validate = dict(
 SI_LENGTH = "si-length"
 SI_LENGTH_RECIPROCAL = "si-length-reciprocal"
 IMPERIAL_LENGTH = "imperial-length"
+ASTRO_LENGTH = "astro-length"
 PIXEL_LENGTH = "pixel-length"
 ANGLE = "angle"
 
@@ -133,6 +136,7 @@ _DIMENSION_LOOKUP = {
     SI_LENGTH: SILengthDimension,
     SI_LENGTH_RECIPROCAL: SILengthReciprocalDimension,
     IMPERIAL_LENGTH: ImperialLengthDimension,
+    ASTRO_LENGTH: AstronomicalLengthDimension,
     PIXEL_LENGTH: PixelLengthDimension,
     ANGLE: AngleDimension,
 }
@@ -212,6 +216,7 @@ class ScaleBar(Artist):
                 * ``:const:`si-length```: scale bar showing km, m, cm, etc.
                 * ``:const:`imperial-length```: scale bar showing in, ft, yd, mi, etc.
                 * ``:const:`si-length-reciprocal```: scale bar showing 1/m, 1/cm, etc.
+                * ``:const:`astro-length```: scale bar showing pc, kpc, Mpc, ly, AU, etc.
                 * ``:const:`pixel-length```: scale bar showing px, kpx, Mpx, etc.
                 * ``:const:`angle```: scale bar showing \u00b0, \u2032 or \u2032\u2032.
                 * a :class:`matplotlib_scalebar.dimension._Dimension` object


### PR DESCRIPTION
This PR adds support for common astronomical lengths, including: 

* Astronomical Units
* Parsecs
* Light-Years

I added it to the README, but I am happy to add any other documentation you would like (or anything else). 