### PR TITLE
Add a (skippable) check that the axes have equal aspect ratio.

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,16 @@ Default: `False`
 ### rotation
 
 Whether to create a scale bar based on the x-axis (default) or y-axis.
-*rotation* can either be `horizontal` or `vertical`.
+*rotation* can either be `horizontal`, `vertical`, `horizontal-only`, or
+`vertical-only`.
+
+By default, matplotlib_scalebar checks whether the axes have equal aspect ratio
+(so that the scale bar applies both for the x and the y directions), and emits
+a warning if this is not the case.  This warning can be suppressed by setting
+*rotation* to `horizontal-only` ("the scale bar only applies to the horizontal
+direction") or `vertical-only` ("the scale bar only applies to the vertical
+direction").
+
 Note you might have to adjust *scale_loc* and *label_loc* to achieve desired layout.
 Default: `None`, value from matplotlibrc or `horizontal`.
 

--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -85,7 +85,7 @@ _validate_label_loc = ValidateInStrings(
     "label_loc", _VALID_LABEL_LOCATIONS, ignorecase=True
 )
 
-_VALID_ROTATIONS = ["horizontal", "vertical"]
+_VALID_ROTATIONS = ["horizontal", "horizontal-only", "vertical", "vertical-only"]
 _validate_rotation = ValidateInStrings("rotation", _VALID_ROTATIONS, ignorecase=True)
 
 
@@ -303,8 +303,11 @@ class ScaleBar(Artist):
         :arg animated: animation state (default: ``False``)
         :type animated: :class`bool`
 
-        :arg rotation: either ``horizontal`` or ``vertical``
-            (default: rcParams['scalebar.rotation'] or ``horizontal``)
+        :arg rotation: ``horizontal``, ``vertical``, ``horizontal-only``, or ``vertical-only``
+            (default: rcParams['scalebar.rotation'] or ``horizontal``).
+            By default, ScaleBar checks that it is getting drawn on an axes
+            with equal aspect ratio and emits a warning if this is not the case.
+            The -only variants suppress that check.
         :type rotation: :class:`str`
 
         :arg bbox_to_anchor: box that is used to position the scalebar
@@ -431,6 +434,14 @@ class ScaleBar(Artist):
         fixed_value = self.fixed_value
         fixed_units = self.fixed_units or self.units
         rotation = _get_value("rotation", "horizontal").lower()
+        if rotation.endswith("-only"):
+            rotation = rotation[:-5]
+        else:  # Check aspect ratio.
+            if self.axes.get_aspect() != 1:
+                warnings.warn(
+                    f"Drawing scalebar on axes with unequal aspect ratio; "
+                    f"either call ax.set_aspect(1) or suppress the warning with "
+                    f"rotation='{rotation}-only'.")
         label = self.label
 
         # Create text properties

--- a/tests/test_scalebar.py
+++ b/tests/test_scalebar.py
@@ -36,6 +36,8 @@ def scalebar():
     yield scalebar
 
     plt.draw()
+    plt.close()
+    del fig
 
 
 def test_mpl_rcParams_update():
@@ -300,8 +302,9 @@ def test_label_formatter(scalebar):
         assert scalebar.label_formatter(value, units) == "m 5"
 
 
-@pytest.mark.parametrize("rotation", [
-    "horizontal", "vertical", "horizontal-only", "vertical-only"])
+@pytest.mark.parametrize(
+    "rotation", ["horizontal", "vertical", "horizontal-only", "vertical-only"]
+)
 def test_rotation(scalebar, rotation):
     assert scalebar.get_rotation() is None
     assert scalebar.rotation is None


### PR DESCRIPTION
When the scalebar is not drawn on an aspect where imshow() has been called (e.g., a point cloud made with plot()), the axes aspect ratio is not automatically set to 1, in which case the scale bar will be wrong (or rather, it will only be correct in the direction (horizontal or vertical) in which it is drawn).

To avoid mistakes, add a check for the aspect ratio, emitting a warning when appropriate.  The check can be skipped by using new variants for `rotation`: it can now be set to "horizontal-only" ("the scalebar only applies to the horizontal direction") or "vertical-only".  (This could also have been a separate kwarg, but something like `check_aspect=False` reads a bit awkwardly to me -- let me know if you'd prefer that.)