### PR TITLE
Autodetect dimension from units.

### DIFF
--- a/matplotlib_scalebar/scalebar.py
+++ b/matplotlib_scalebar/scalebar.py
@@ -174,7 +174,7 @@ class ScaleBar(Artist):
         self,
         dx,
         units="m",
-        dimension="si-length",
+        dimension="auto",
         label=None,
         length_fraction=None,
         height_fraction=None,
@@ -230,6 +230,7 @@ class ScaleBar(Artist):
                 * ``:const:`pixel-length```: scale bar showing px, kpx, Mpx, etc.
                 * ``:const:`angle```: scale bar showing \u00b0, \u2032 or \u2032\u2032.
                 * a :class:`matplotlib_scalebar.dimension._Dimension` object
+                * ``:const:`auto``` (the default): autodetect dimension based on *units*
         :type dimension: :class:`str` or
             :class:`matplotlib_scalebar.dimension._Dimension`
 
@@ -355,7 +356,14 @@ class ScaleBar(Artist):
             raise ValueError("loc and location are specified and not equal")
 
         self.dx = dx
-        self.dimension = dimension  # Should be initialize before units
+        if dimension == "auto":
+            for cls in _DIMENSION_LOOKUP.values():
+                dimension = cls()
+                if dimension.is_valid_units(units):
+                    break
+            else:
+                raise ValueError(f"Invalid unit ({units})")
+        self.dimension = dimension  # Should be initialized before units
         self.units = units
         self.label = label
         self.length_fraction = length_fraction

--- a/tests/test_scalebar.py
+++ b/tests/test_scalebar.py
@@ -398,3 +398,8 @@ def test_info():
 
     plt.close()
     del fig
+
+
+def test_auto_dimension():
+    assert ScaleBar(1, "kpc").dimension.base_units == "pc"
+    assert ScaleBar(1, "1/um").dimension.base_units == "1/m"


### PR DESCRIPTION
This lets one write `ScaleBar(1, "kpc")` instead of the slightly redundant `ScaleBar(1, "kpc", "astro-length")`.

Note that changes only occur in the constructor; "auto" is not when later calling set_dimension (directly or via the property) because that property's mutable semantics seem a bit fuzzy anyways: what happens if one sets the dimension to something incompatible with the units?  I would believe `ScaleBar.dimension` should be a readonly property directly derived from `ScaleBar.units`.

Closes #70.